### PR TITLE
[WIP] Add AFK functionality.

### DIFF
--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -1,0 +1,10 @@
+from discord.ext import commands
+
+
+class AFK(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+
+def setup(bot):
+    bot.add_cog(AFK(bot=bot))

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -122,6 +122,20 @@ class Help(commands.Cog, name='Help'):
         bot.help_command = CustomHelp()
         bot.help_command.cog = self
 
+    @commands.command(name='support')
+    async def support_server(self, ctx):
+        """
+        Gives a link to the support server
+        """
+        support_guild = self.bot.get_guild(755202524859859004)
+
+        embed = create_default_embed(ctx)
+        embed.title = 'FrogBot Support Server'
+        embed.description = '[Link to support server](https://discord.gg/U5qN8qwQHN)'
+        if support_guild is not None:
+            embed.set_thumbnail(url=support_guild.icon_url)
+        return await ctx.send(embed=embed)
+
     def cog_unload(self):
         self.bot.help_command = self._original_help_command
 

--- a/dbot.py
+++ b/dbot.py
@@ -14,7 +14,7 @@ import sentry_sdk
 
 COGS = (
     'cogs.util', 'jishaku', 'cogs.admin', 'cogs.error_handeling', 'cogs.custom_commands',
-    'cogs.quest_roles', 'cogs.dm_commands', 'cogs.sheet_approval', 'cogs.afk'
+    'cogs.quest_roles', 'cogs.dm_commands', 'cogs.sheet_approval', 'cogs.afk',
     'cogs.help'
 )
 

--- a/dbot.py
+++ b/dbot.py
@@ -14,7 +14,7 @@ import sentry_sdk
 
 COGS = (
     'cogs.util', 'jishaku', 'cogs.admin', 'cogs.error_handeling', 'cogs.custom_commands',
-    'cogs.quest_roles', 'cogs.dm_commands', 'cogs.sheet_approval',
+    'cogs.quest_roles', 'cogs.dm_commands', 'cogs.sheet_approval', 'cogs.afk'
     'cogs.help'
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,13 @@
 aiohttp==3.6.3
-aniso8601==8.0.0
 astunparse==1.6.3
 async-timeout==3.0.1
 attrs==20.2.0
 braceexpand==0.1.6
-certifi==2020.11.8
 chardet==3.0.4
 click==7.1.2
-git+https://github.com/Rapptz/discord-ext-menus
+discord-ext-menus @ git+https://github.com/Rapptz/discord-ext-menus@6f2b873bf0d28903eb752aa1166b3aac26dc9007
 discord.py==1.5.1
 dnspython==2.0.0
-Flask==1.1.2
-Flask-RESTful==0.3.8
 humanize==3.1.0
 idna==2.10
 import-expression==1.1.4
@@ -22,9 +18,7 @@ MarkupSafe==1.1.1
 motor==2.3.0
 multidict==4.7.6
 pymongo==3.11.0
-pytz==2020.4
 sentry-sdk==0.19.2
 six==1.15.0
-urllib3==1.26.0
 Werkzeug==1.0.1
 yarl==1.5.1

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -10,7 +10,7 @@ async def try_delete(message):
 
 
 def create_default_embed(ctx) -> discord.Embed:
-    embed = discord.Embed(color=discord.Color(int('0x512888', base=16)))
+    embed = discord.Embed(color=discord.Color(int('0x2F3136', base=16)))
     bot = ctx.bot
     embed.set_author(name=ctx.message.author.display_name, icon_url=str(ctx.message.author.avatar_url))
     embed.set_footer(text=bot.user.name, icon_url=str(bot.user.avatar_url))


### PR DESCRIPTION
AFK roles (Suggested by Grappa)

Add a way to identify AFK users by nickname

Notes: Guild-Only Cog, member.edit, check for manage_nicknames permission
Problem: Cannot change nickname of Member above you
Solution: Move NPC role to the top

- [ ] .afk (reason) - Toggles AFK user in database 
- [ ] Change nickname to include [AFK]
- [ ] .isafk (user) - Checks if a user is AFK, and if so, gives reason